### PR TITLE
[Feature] Improve compatibility of CPU-based Env on exisiting workflows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,17 +148,22 @@ Currently, EvoRL supports 4 types of algorithms
 
 # RL Environments
 
-By default, `pip install evorl` will automatically install environments on `brax` and `gymnasium`. If you want to use other supported environments, please install the additional environment packages. For example:
+By default, `pip install evorl` will automatically install environments on `brax`. If you want to use other supported environments, please install the additional environment packages. For example:
 
 ```shell
+# ===== GPU-accelerated Environments =====
 # gymnax Envs:
 pip install gymnax
-# EnvPool Envs:
-pip install envpool "numpy<2.0.0"
 # Jumanji Envs:
 pip install jumanji
 # JaxMARL Envs:
 pip install jaxmarl
+
+# ===== CPU-based Environments =====
+# EnvPool Envs: (also require py<3.12)
+pip install envpool "numpy<2.0.0"
+# Gymnasium Envs:
+pip install "gymnasium[atari,mujoco,classic-control,box2d]>=1.1.0"
 ```
 
 > [!WARNING]

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -17,17 +17,22 @@ pip install -e .
 
 ## RL Environments
 
-By default, `pip install evorl` will automatically install environments on `brax` and `gymnasium`. If you want to install other supported environments, you need manually install the related environment packages. For example:
+By default, `pip install evorl` will automatically install environments on `brax`. If you want to install other supported environments, you need manually install the related environment packages. For example:
 
 ```shell
+# ===== GPU-accelerated Environments =====
 # gymnax Envs:
 pip install gymnax
-# EnvPool Envs:
-pip install envpool "numpy<2.0.0"
 # Jumanji Envs:
 pip install jumanji
 # JaxMARL Envs:
 pip install jaxmarl
+
+# ===== CPU-based Environments =====
+# EnvPool Envs: (also require py<3.12)
+pip install envpool "numpy<2.0.0"
+# Gymnasium Envs:
+pip install "gymnasium[atari,mujoco,classic-control,box2d]>=1.1.0"
 ```
 
 | Environment Library                                                        | Descriptions                            |

--- a/evorl/envs/brax.py
+++ b/evorl/envs/brax.py
@@ -100,7 +100,7 @@ def create_wrapped_brax_env(
         parallel: Number of parallel environments.
         autoreset_mode: Autoreset mode.
         discount: Discount factor.
-        record_ori_obs: Whether record original observation.
+        record_ori_obs: Whether record original observation in AutoresetMode.NORMAL and AutoresetMode.FAST mode.
         kwargs: Other arguments passing into Brax.
 
     Returns:


### PR DESCRIPTION
This PR includes:

- Improved `create_envpool_env` and `create_gymnasium_env` API to support arguments in other JAX-based Envs.
  - Envpool Envs still only support workflows that use AutoresetMode.ENVPOOL
  - Gymnasium Envs additionally support AutoresetMode.NORMAL, should be compatible with most of the existing workflows.
- Improved doc for install environment requirements.